### PR TITLE
Remove @next/swc from runtime deps package

### DIFF
--- a/.github/workflows/r_build-app.yml
+++ b/.github/workflows/r_build-app.yml
@@ -131,6 +131,8 @@ jobs:
           cp -R ./packages/app/.next ./packages/cdk-construct/lib/${{ inputs.APP_CONSTRUCT_FOLDER_NAME }}
           rm -rf ./packages/cdk-construct/lib/${{ inputs.APP_CONSTRUCT_FOLDER_NAME }}/.next/cache
           cp -R ./packages/app/next.config.js ./packages/cdk-construct/lib/${{ inputs.APP_CONSTRUCT_FOLDER_NAME }}
+          # Remove the SWC files from the runtime deps (these are dev time only)
+          rm -rf ./packages/app-entry/runtime-deps/node_modules/@next/swc-*
           cp -R ./packages/app-entry/runtime-deps/node_modules ./packages/cdk-construct/lib/${{ inputs.APP_CONSTRUCT_FOLDER_NAME }}
 
       # Prevent the static files from getting pulled into the Lambda


### PR DESCRIPTION
- The `@next/swc` packages get included in the runtime deps and they are *enormous* (75 MB)